### PR TITLE
Fix/handle exif orientation when read image file

### DIFF
--- a/android/src/main/java/com/guhungry/rnphotomanipulator/utils/ImageUtils.kt
+++ b/android/src/main/java/com/guhungry/rnphotomanipulator/utils/ImageUtils.kt
@@ -17,8 +17,15 @@ object ImageUtils {
      */
     @JvmOverloads
     @JvmStatic fun bitmapFromUri(context: Context, uri: String, options: BitmapFactory.Options? = null): Bitmap {
-        openBitmapInputStream(context, uri).use {
-            return BitmapFactory.decodeStream(it, null, options)!!
+        openBitmapInputStream(context, uri).use { image ->
+            val matrix = openBitmapInputStream(context, uri).use {
+                BitmapUtils.getCorrectOrientationMatrix(it)
+            }
+
+            val bitmap: Bitmap = BitmapFactory.decodeStream(image, null, options)!!
+
+            return if (matrix != null) Bitmap.createBitmap(bitmap, 0, 0, bitmap.width,
+                bitmap.height, matrix, true).also { bitmap.recycle()  } else bitmap
         }
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-photo-manipulator",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "Image processing library to edit photo programmatically in React Native",
   "main": "index.js",
   "typings": "index.d.ts",


### PR DESCRIPTION
Last place left to handle orientation in EXIF data correctly should fix #343 and #376

Before
<img width="286" alt="Screen Shot 2021-09-21 at 19 44 39" src="https://user-images.githubusercontent.com/4032276/134173478-8a9dd16b-8382-40dd-81e0-44f3efeda058.png">

After
<img width="279" alt="Screen Shot 2021-09-21 at 19 46 24" src="https://user-images.githubusercontent.com/4032276/134173523-41a0f1bd-6925-4608-a5d6-f3e53bb64b00.png">
