### PR TITLE
Fix/error compile 1.4.0 with rn 0.72

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,4 +1,4 @@
-RNPM_kotlinVersion=1.5.30
+RNPM_kotlinVersion=1.8.10
 RNPM_compileSdkVersion=30
 RNPM_minSdkVersion=21
 RNPM_targetSdkVersion=30

--- a/android/src/main/java/com/guhungry/rnphotomanipulator/RNPhotoManipulatorPackage.java
+++ b/android/src/main/java/com/guhungry/rnphotomanipulator/RNPhotoManipulatorPackage.java
@@ -35,6 +35,7 @@ public class RNPhotoManipulatorPackage extends TurboReactPackage {
                             RNPhotoManipulatorModuleImpl.NAME,
                             false, // canOverrideExistingModule
                             false, // needsEagerInit
+                            false, // hasConstants
                             false, // isCxxModule
                             turboModulesEnabled // isTurboModule
                     ));


### PR DESCRIPTION
Addresses issue #806

Fail to compile library version 1.4.0 in android with React Native 0.72.12
- [x] Update default kotlinVersion 1.8.10 to support gradle 8.0.1 used in React Native 0.72 template
- [x] Use deprecated method to register native module until deleted in the future version