### PR TITLE
[iOS@CocoaPod] Error when run install pod with React Native < 0.71

### DIFF
--- a/react-native-photo-manipulator.podspec
+++ b/react-native-photo-manipulator.podspec
@@ -18,6 +18,10 @@ Pod::Spec.new do |s|
 
   s.dependency 'WCPhotoManipulator', '~> 2.3.0'
 
-  # React Native Core dependency
-  install_modules_dependencies(s)
+  if respond_to?(:install_modules_dependencies, true)
+    # React Native Core dependency
+    install_modules_dependencies(s)
+  else
+    s.dependency "React-Core"
+  end
 end


### PR DESCRIPTION
Might related to #855

When I tried to run `pod install` with React Native 0.64.4, I got the error below
```
[2024-07-20 11:43:21] ios % pod install

[!] Invalid `Podfile` file: 
[!] Invalid `react-native-photo-manipulator.podspec` file: undefined method `install_modules_dependencies' for module Pod.

 #  from /**censored**/node_modules/react-native-photo-manipulator/react-native-photo-manipulator.podspec:22
```

After investigate `install_modules_dependencies` was added in React Native 0.71 as described [here](https://reactnative.dev/blog/2023/01/12/version-071#developer-experience-improvements)

So we need to check for `install_modules_dependencies` availability for backward compatible
https://github.com/guhungry/react-native-photo-manipulator/blob/master/react-native-photo-manipulator.podspec#L21-L22