### PR TITLE
[Android] Fix: Native module didn't compiled in React Native 0.64.4

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,7 +38,17 @@ apply plugin: 'kotlin-android'
 android {
     compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
 
-    namespace "com.guhungry.rnphotomanipulator"
+    def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
+    // Check AGP version for backward compatibility reasons
+    if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
+        namespace "com.guhungry.rnphotomanipulator"
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
     defaultConfig {
         minSdkVersion getExtOrIntegerDefault('minSdkVersion')
         targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
@@ -77,5 +87,5 @@ repositories {
 dependencies {
     implementation 'com.facebook.react:react-native:+'
     implementation "org.jetbrains.kotlin:kotlin-stdlib:${getExtOrDefault('kotlinVersion')}"
-    implementation "com.guhungry.android:photo-manipulator:1.2.2"
+    implementation "com.guhungry.android:photo-manipulator:1.2.3"
 }

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
-</manifest>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          package="com.guhungry.rnphotomanipulator" />

--- a/android/src/main/java/com/guhungry/rnphotomanipulator/RNPhotoManipulatorPackage.java
+++ b/android/src/main/java/com/guhungry/rnphotomanipulator/RNPhotoManipulatorPackage.java
@@ -4,16 +4,35 @@ package com.guhungry.rnphotomanipulator;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.facebook.react.ReactPackage;
 import com.facebook.react.TurboReactPackage;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.module.model.ReactModuleInfo;
 import com.facebook.react.module.model.ReactModuleInfoProvider;
+import com.facebook.react.uimanager.ViewManager;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
-public class RNPhotoManipulatorPackage extends TurboReactPackage {
+public class RNPhotoManipulatorPackage extends TurboReactPackage implements ReactPackage {
+    @NonNull
+    @Override
+    public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
+        List<NativeModule> modules = new ArrayList<>();
+        modules.add(new RNPhotoManipulatorModule(reactContext));
+        return modules;
+    }
+
+    @NonNull
+    @Override
+    public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
+        return Collections.emptyList();
+    }
+
     @Nullable
     @Override
     public NativeModule getModule(@NonNull String name, @NonNull ReactApplicationContext reactContext) {


### PR DESCRIPTION
Version 1.52 when run in Android on React Native 0.64.4 will encounter the error as in #855.

Root Cause:
Due to when add support for new architecture in #788 RNPhotoManipulatorPackage needs to extends from TurboReactPackage instead of implements ReactPackage
which `react-native config` use `ReactPackage` to generate config but found `TurboReactPackage` instead so config for Android is null, so this library isn't compiled in android