### PR TITLE
Fix/ios codegen doesnt work

### DIFF
--- a/example/.maestro/batch/batch-tests.yaml
+++ b/example/.maestro/batch/batch-tests.yaml
@@ -5,9 +5,8 @@ appId: photomanipulator.example
 - scrollUntilVisible:
     element:
       id: "example-exampleBatch"
-    direction: DOWN
-    visibilityPercentage: 80
-    timeout: 50000
+    visibilityPercentage: 60
+    timeout: 60000
     speed: 80
 - assertVisible:
     id: "example-exampleBatch"
@@ -15,8 +14,7 @@ appId: photomanipulator.example
 - scrollUntilVisible:
     element:
       id: "batchResult"
-    direction: DOWN
-    visibilityPercentage: 80
+    visibilityPercentage: 60
     timeout: 30000
     speed: 60
 - assertVisible:
@@ -25,8 +23,7 @@ appId: photomanipulator.example
 - scrollUntilVisible:
     element:
       id: "batchResultPng"
-    direction: DOWN
-    visibilityPercentage: 80
+    visibilityPercentage: 60
     timeout: 30000
     speed: 60
 - assertVisible:

--- a/example/.maestro/crop/crop-tests.yaml
+++ b/example/.maestro/crop/crop-tests.yaml
@@ -5,7 +5,6 @@ appId: photomanipulator.example
 - scrollUntilVisible:
     element:
       id: "example-exampleCrop"
-    direction: DOWN
     visibilityPercentage: 60
     timeout: 60000
     speed: 80
@@ -15,8 +14,7 @@ appId: photomanipulator.example
 - scrollUntilVisible:
     element:
       id: "cropResult"
-    direction: DOWN
-    visibilityPercentage: 80
+    visibilityPercentage: 60
     timeout: 30000
     speed: 60
 - assertVisible:
@@ -25,8 +23,7 @@ appId: photomanipulator.example
 - scrollUntilVisible:
     element:
       id: "cropResizeResult"
-    direction: DOWN
-    visibilityPercentage: 80
+    visibilityPercentage: 60
     timeout: 30000
     speed: 60
 - assertVisible:
@@ -35,8 +32,7 @@ appId: photomanipulator.example
 - scrollUntilVisible:
     element:
       id: "cropPngResult"
-    direction: DOWN
-    visibilityPercentage: 80
+    visibilityPercentage: 60
     timeout: 30000
     speed: 60
 - assertVisible:

--- a/example/.maestro/flip/flip-tests.yaml
+++ b/example/.maestro/flip/flip-tests.yaml
@@ -5,7 +5,6 @@ appId: photomanipulator.example
 - scrollUntilVisible:
     element:
       id: "example-exampleFlip"
-    direction: DOWN
     visibilityPercentage: 60
     timeout: 60000
     speed: 80
@@ -15,8 +14,7 @@ appId: photomanipulator.example
 - scrollUntilVisible:
     element:
       id: "flipBothResult"
-    direction: DOWN
-    visibilityPercentage: 80
+    visibilityPercentage: 60
     timeout: 30000
     speed: 60
 - assertVisible:
@@ -25,8 +23,7 @@ appId: photomanipulator.example
 - scrollUntilVisible:
     element:
       id: "flipHorizontalResult"
-    direction: DOWN
-    visibilityPercentage: 80
+    visibilityPercentage: 60
     timeout: 30000
     speed: 60
 - assertVisible:
@@ -35,8 +32,7 @@ appId: photomanipulator.example
 - scrollUntilVisible:
     element:
       id: "flipVerticalResult"
-    direction: DOWN
-    visibilityPercentage: 80
+    visibilityPercentage: 60
     timeout: 30000
     speed: 60
 - assertVisible:

--- a/example/.maestro/optimize/optimize-tests.yaml
+++ b/example/.maestro/optimize/optimize-tests.yaml
@@ -5,7 +5,6 @@ appId: photomanipulator.example
 - scrollUntilVisible:
     element:
       id: "example-exampleOptimize"
-    direction: DOWN
     visibilityPercentage: 60
     timeout: 60000
     speed: 80

--- a/example/.maestro/overlay/overlay-tests.yaml
+++ b/example/.maestro/overlay/overlay-tests.yaml
@@ -5,9 +5,8 @@ appId: photomanipulator.example
 - scrollUntilVisible:
     element:
       id: "example-exampleOverlayImage"
-    direction: DOWN
-    visibilityPercentage: 80
-    timeout: 30000
+    visibilityPercentage: 60
+    timeout: 60000
     speed: 80
 - assertVisible:
     id: "example-exampleOverlayImage"
@@ -19,8 +18,8 @@ appId: photomanipulator.example
     element:
       id: "overlayImagePngResult"
     direction: DOWN
-    visibilityPercentage: 80
+    visibilityPercentage: 60
     timeout: 30000
-    speed: 80
+    speed: 60
 - assertVisible:
     id: "overlayImagePngResult"

--- a/example/.maestro/print-text/print-text-tests.yaml
+++ b/example/.maestro/print-text/print-text-tests.yaml
@@ -5,9 +5,8 @@ appId: photomanipulator.example
 - scrollUntilVisible:
     element:
       id: "example-examplePrintText"
-    direction: DOWN
-    visibilityPercentage: 70
-    timeout: 30000
+    visibilityPercentage: 60
+    timeout: 60000
     speed: 80
 - assertVisible:
     id: "example-examplePrintText"
@@ -18,9 +17,8 @@ appId: photomanipulator.example
 - scrollUntilVisible:
     element:
       id: "printTextPngResult"
-    direction: DOWN
-    visibilityPercentage: 80
+    visibilityPercentage: 60
     timeout: 30000
-    speed: 80
+    speed: 60
 - assertVisible:
     id: "printTextPngResult"

--- a/example/.maestro/rotate/rotate-tests.yaml
+++ b/example/.maestro/rotate/rotate-tests.yaml
@@ -5,7 +5,6 @@ appId: photomanipulator.example
 - scrollUntilVisible:
     element:
       id: "example-exampleRotate"
-    direction: DOWN
     visibilityPercentage: 60
     timeout: 60000
     speed: 80
@@ -15,8 +14,7 @@ appId: photomanipulator.example
 - scrollUntilVisible:
     element:
       id: "rotate90Result"
-    direction: DOWN
-    visibilityPercentage: 80
+    visibilityPercentage: 60
     timeout: 30000
     speed: 60
 - assertVisible:
@@ -25,8 +23,7 @@ appId: photomanipulator.example
 - scrollUntilVisible:
     element:
       id: "rotate180Result"
-    direction: DOWN
-    visibilityPercentage: 80
+    visibilityPercentage: 60
     timeout: 30000
     speed: 60
 - assertVisible:
@@ -35,8 +32,7 @@ appId: photomanipulator.example
 - scrollUntilVisible:
     element:
       id: "rotate270Result"
-    direction: DOWN
-    visibilityPercentage: 80
+    visibilityPercentage: 60
     timeout: 30000
     speed: 60
 - assertVisible:

--- a/example/.maestro/sanity/sanity-tests.yaml
+++ b/example/.maestro/sanity/sanity-tests.yaml
@@ -11,63 +11,55 @@ appId: photomanipulator.example
 - scrollUntilVisible:
     element:
       id: "example-overlayImage"
-    direction: DOWN
-    visibilityPercentage: 80
+    visibilityPercentage: 60
 - assertVisible:
     id: "example-overlayImage"
 
 - scrollUntilVisible:
     element:
       id: "example-exampleFlip"
-    direction: DOWN
-    visibilityPercentage: 80
+    visibilityPercentage: 60
 - assertVisible:
     id: "example-exampleFlip"
 
 - scrollUntilVisible:
     element:
       id: "example-exampleRotate"
-    direction: DOWN
-    visibilityPercentage: 80
+    visibilityPercentage: 60
 - assertVisible:
     id: "example-exampleRotate"
 
 - scrollUntilVisible:
     element:
       id: "example-exampleOverlayImage"
-    direction: DOWN
-    visibilityPercentage: 80
+    visibilityPercentage: 60
 - assertVisible:
     id: "example-exampleOverlayImage"
 
 - scrollUntilVisible:
     element:
       id: "example-examplePrintText"
-    direction: DOWN
-    visibilityPercentage: 80
+    visibilityPercentage: 60
 - assertVisible:
     id: "example-examplePrintText"
 
 - scrollUntilVisible:
     element:
       id: "example-exampleCrop"
-    direction: DOWN
-    visibilityPercentage: 80
+    visibilityPercentage: 60
 - assertVisible:
     id: "example-exampleCrop"
 
 - scrollUntilVisible:
     element:
       id: "example-exampleOptimize"
-    direction: DOWN
-    visibilityPercentage: 80
+    visibilityPercentage: 60
 - assertVisible:
     id: "example-exampleOptimize"
 
 - scrollUntilVisible:
     element:
       id: "example-exampleBatch"
-    direction: DOWN
-    visibilityPercentage: 80
+    visibilityPercentage: 60
 - assertVisible:
     id: "example-exampleBatch"

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1237,7 +1237,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-photo-manipulator (1.7.2):
+  - react-native-photo-manipulator (1.7.3):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1547,7 +1547,7 @@ PODS:
     - React-jsi
   - ReactTestApp-Resources (1.0.0-dev)
   - SocketRocket (0.7.0)
-  - WCPhotoManipulator (2.4.0)
+  - WCPhotoManipulator (2.4.5)
   - Yoga (0.0.0)
 
 DEPENDENCIES:
@@ -1796,7 +1796,7 @@ SPEC CHECKSUMS:
   React-logger: d79b704bf215af194f5213a6b7deec50ba8e6a9b
   React-Mapbuffer: b982d5bba94a8bc073bda48f0d27c9b28417fae3
   React-microtasksnativemodule: 2cec1d6e126598df0f165268afa231174dd1a611
-  react-native-photo-manipulator: 1f9f71ad80cbc3c571e7c03db6b7655ae8677d4c
+  react-native-photo-manipulator: 524d5b422b88afc51643510037c2964aaef5ff41
   React-nativeconfig: 8c83d992b9cc7d75b5abe262069eaeea4349f794
   React-NativeModulesApple: 9f7920224a3b0c7d04d77990067ded14cee3c614
   React-perflogger: 59e1a3182dca2cee7b9f1f7aab204018d46d1914
@@ -1827,7 +1827,7 @@ SPEC CHECKSUMS:
   ReactTestApp-DevSupport: ed439cce949caf074af3ae05051b4bd157ed4019
   ReactTestApp-Resources: 4636447c40726b843aab474e2fe6ef5b897952e8
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
-  WCPhotoManipulator: ed75cbf88c7a32a829e64bb203136ad620cbce81
+  WCPhotoManipulator: 1a35d40ae966b7fbc3954cd6597448fd953f3852
   Yoga: 055f92ad73f8c8600a93f0e25ac0b2344c3b07e6
 
 PODFILE CHECKSUM: 655fdb7d5e7844c47be69bf3213a13dc508787a2

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "main": "./lib/commonjs/index.js",
   "module": "./lib/module/index.js",
   "exports": {
+    "./package.json": "./package.json",
     ".": {
       "import": {
         "types": "./lib/typescript/module/src/index.d.ts",

--- a/turbo.json
+++ b/turbo.json
@@ -54,7 +54,8 @@
         "!example/ios/Pods"
       ],
       "outputs": [
-        "dist/**"
+        "dist/**",
+        "example/dist/**"
       ]
     },
     "test:ios:build": {
@@ -71,7 +72,8 @@
         "!example/ios/Pods"
       ],
       "outputs": [
-        "ios/build/**/ReactTestApp.app/**"
+        "ios/build/**/ReactTestApp.app/**",
+        "example/ios/build/**/ReactTestApp.app/**"
       ]
     }
   }


### PR DESCRIPTION
Codegen doesn't find library so when new architecture is enabled it will build fail as in https://github.com/guhungry/react-native-photo-manipulator/issues/942
For solution we can add export package.json  as described in https://github.com/callstack/react-native-builder-bob/issues/637