### PR TITLE
Fix can't compile android in React Native 0.76

### DIFF
--- a/android/src/main/java/com/guhungry/rnphotomanipulator/utils/ImageUtils.kt
+++ b/android/src/main/java/com/guhungry/rnphotomanipulator/utils/ImageUtils.kt
@@ -79,7 +79,7 @@ object ImageUtils {
         return when {
             output.isMutable -> output
             else -> try {
-                output.copy(output.config, true)
+                output.copy(output.config ?: Bitmap.Config.ARGB_8888, true)
             } finally {
                 output.recycle()
             }


### PR DESCRIPTION
Android error due to changes in Bitmap.getConfig() from @NonNull in Android <= 34 to @Nullable in Android 35

Android 34
<img width="370" alt="Screenshot 2567-10-24 at 20 28 11" src="https://github.com/user-attachments/assets/c0e9eb08-72ed-4db2-8246-f5a40464df4c">

Android 35
<img width="670" alt="Screenshot 2567-10-24 at 20 27 59" src="https://github.com/user-attachments/assets/f40d62c7-5a38-4713-87ee-b5b427b80b1e">
