### PR TITLE
Feature/text alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ import RNPhotoManipulator from 'react-native-photo-manipulator';
     * [`Point`](README.md#point)
     * [`Rect`](README.md#rect)
     * [`Size`](README.md#size)
+    * [`TextAlign`](README.md#textalign)
     * [`TextDirection`](README.md#textdirection)
     * [`TextOptions`](README.md#textoptions)
 ### Method
@@ -392,6 +393,15 @@ Represent size (width, height) of region or image
 | `width`         | number    | The width of the region  |
 | `height`        | number    | The height of the region |
 
+#### TextAlign
+Enum represent text align
+
+| Enum            | Description                                                       |
+| --------------- | ----------------------------------------------------------------- |
+| START           | Align text to the start of the line (e.g., left-aligned text in LTR, right-aligned text in RTL)            |
+| CENTER          | Align text to the center of the line                              |
+| END             | Align text to the end of the line (e.g., right-aligned text in LTR, left-aligned text in RTL)               |
+
 #### TextDirection
 Enum represent text direction, this will affect coordinate and alignment
 
@@ -416,3 +426,4 @@ Represent attributes of text such as text, color, size, and etc.
 | `shadowOffset`      | [`Point`](README.md#point)                        | No       | The shadow offset                |
 | `shadowColor`         | string                        | No       | The color of the shadow                          |
 | `direction`         | [`TextDirection`](README.md#textdirection) | No       | The direction of the text, default to TextDirection.LTR       |
+| `align`             | [`TextAlign`](README.md#textalign) | No       | The direction of the text, default to TextAlign.START       |

--- a/README.md
+++ b/README.md
@@ -393,12 +393,12 @@ Represent size (width, height) of region or image
 | `height`        | number    | The height of the region |
 
 #### TextDirection
-Enum represent text direction
+Enum represent text direction, this will affect coordinate and alignment
 
 | Enum            | Description                                                       |
 | --------------- | ----------------------------------------------------------------- |
-| LTR             | Left-to-Right text direction (e.g., English, Spanish)             |
-| RTL             | Right-to-Left text direction (e.g., Arabic, Hebrew)               |
+| LTR             | Left-to-Right text direction (e.g., English, Spanish) `[Top-Left, Right]`            |
+| RTL             | Right-to-Left text direction (e.g., Arabic, Hebrew) `[Top-Right, Right]`               |
 
 #### TextOptions
 Represent attributes of text such as text, color, size, and etc.

--- a/android/src/main/java/com/guhungry/rnphotomanipulator/RNPhotoManipulatorModule.kt
+++ b/android/src/main/java/com/guhungry/rnphotomanipulator/RNPhotoManipulatorModule.kt
@@ -28,6 +28,8 @@ import com.guhungry.rnphotomanipulator.utils.ParamUtils.toRotationMode
 import com.guhungry.rnphotomanipulator.utils.ParamUtils.toCGSize
 
 private const val LANGUAGE_RTL = "rtl"
+private const val ALIGNMENT_CENTER = "center"
+private const val ALIGNMENT_END = "end"
 
 class RNPhotoManipulatorModule(private val context: ReactApplicationContext) : RNPhotoManipulatorSpec(context) {
     override fun getName(): String {
@@ -183,14 +185,9 @@ class RNPhotoManipulatorModule(private val context: ReactApplicationContext) : R
         val isRTL = LANGUAGE_RTL == options.getString("direction")
 
         // Adjust the alignment based on the text direction (RTL or LTR)
-        val alignment = if (isRTL) Paint.Align.RIGHT else Paint.Align.LEFT
+        val alignment = toTextAlign(isRTL, options.getString("align"))
 
-        // Adjust the location for RTL text
-        val adjustedLocation = if (isRTL) {
-            PointF(image.width - location.x, location.y)  // Flip location for RTL
-        } else {
-            location
-        }
+        val adjustedLocation = toAdjustedLocation(isRTL, location, image.width)
 
         // Set the text style, including shadow, alignment, etc.
         val style = TextStyle(
@@ -208,6 +205,19 @@ class RNPhotoManipulatorModule(private val context: ReactApplicationContext) : R
 
         // Print the text on the image with the adjusted location and style
         printText(image, bidiFormatter.unicodeWrap(text), adjustedLocation, style)
+    }
+
+
+    private fun toAdjustedLocation(isRTL: Boolean, location: PointF, imageWidth: Int) = if (isRTL) {
+        PointF(imageWidth - location.x, location.y)  // Flip location for RTL
+    } else {
+        location
+    }
+
+    private fun toTextAlign(isRTL: Boolean, align: String?): Paint.Align {
+        if (ALIGNMENT_CENTER == align) return Paint.Align.CENTER
+        if (ALIGNMENT_END == align) return if (isRTL) Paint.Align.LEFT else Paint.Align.RIGHT
+        return if (isRTL) Paint.Align.RIGHT else Paint.Align.LEFT
     }
 
     private fun getFont(fontName: String?): Typeface {

--- a/example/app/example/ExamplePrintText.tsx
+++ b/example/app/example/ExamplePrintText.tsx
@@ -4,6 +4,7 @@ import styles, { ImageResultProps } from '../App.styles';
 import { noop } from '../utils';
 import PhotoManipulator, {
   MimeType,
+  TextAlign,
   TextDirection,
 } from 'react-native-photo-manipulator';
 import type { TextOptions } from 'react-native-photo-manipulator';
@@ -124,6 +125,51 @@ export default React.memo(function ExamplePrintText() {
         color: 'blue',
         textSize: 500,
         position: { x: 80, y: 300 },
+        direction: TextDirection.RTL,
+      },
+      {
+        text: 'LTR Start',
+        color: 'green',
+        textSize: 300,
+        position: { x: 1000, y: 2050 },
+        align: TextAlign.START,
+      },
+      {
+        text: 'LTR Center',
+        color: 'green',
+        textSize: 300,
+        position: { x: 1000, y: 2550 },
+        align: TextAlign.CENTER,
+      },
+      {
+        text: 'LTR End',
+        color: 'green',
+        textSize: 300,
+        position: { x: 1000, y: 3050 },
+        align: TextAlign.END,
+      },
+      {
+        text: 'RTL Start',
+        color: 'green',
+        textSize: 300,
+        position: { x: 1000, y: 3550 },
+        align: TextAlign.START,
+        direction: TextDirection.RTL,
+      },
+      {
+        text: 'RTL Center',
+        color: 'green',
+        textSize: 300,
+        position: { x: 1000, y: 4050 },
+        align: TextAlign.CENTER,
+        direction: TextDirection.RTL,
+      },
+      {
+        text: 'RTL End',
+        color: 'green',
+        textSize: 300,
+        position: { x: 1000, y: 4550 },
+        align: TextAlign.END,
         direction: TextDirection.RTL,
       },
     ];

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1237,7 +1237,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-photo-manipulator (1.8.0):
+  - react-native-photo-manipulator (1.8.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1257,7 +1257,7 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - WCPhotoManipulator (~> 2.5.0)
+    - WCPhotoManipulator (~> 2.6.0)
     - Yoga
   - React-nativeconfig (0.75.4)
   - React-NativeModulesApple (0.75.4):
@@ -1547,7 +1547,7 @@ PODS:
     - React-jsi
   - ReactTestApp-Resources (1.0.0-dev)
   - SocketRocket (0.7.0)
-  - WCPhotoManipulator (2.5.0)
+  - WCPhotoManipulator (2.6.0)
   - Yoga (0.0.0)
 
 DEPENDENCIES:
@@ -1796,7 +1796,7 @@ SPEC CHECKSUMS:
   React-logger: d79b704bf215af194f5213a6b7deec50ba8e6a9b
   React-Mapbuffer: b982d5bba94a8bc073bda48f0d27c9b28417fae3
   React-microtasksnativemodule: 2cec1d6e126598df0f165268afa231174dd1a611
-  react-native-photo-manipulator: 7d2e396976f333ca6999676c02f4283c0a68d384
+  react-native-photo-manipulator: 89e1f3353ad4390570367785364733d37dbfd033
   React-nativeconfig: 8c83d992b9cc7d75b5abe262069eaeea4349f794
   React-NativeModulesApple: 9f7920224a3b0c7d04d77990067ded14cee3c614
   React-perflogger: 59e1a3182dca2cee7b9f1f7aab204018d46d1914
@@ -1827,7 +1827,7 @@ SPEC CHECKSUMS:
   ReactTestApp-DevSupport: ed439cce949caf074af3ae05051b4bd157ed4019
   ReactTestApp-Resources: 4636447c40726b843aab474e2fe6ef5b897952e8
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
-  WCPhotoManipulator: 76b459c73d9ef10106ca98537b58e381d78b58b1
+  WCPhotoManipulator: 804988e16a6fe941cddff942b2acf887110de5d6
   Yoga: 055f92ad73f8c8600a93f0e25ac0b2344c3b07e6
 
 PODFILE CHECKSUM: 655fdb7d5e7844c47be69bf3213a13dc508787a2

--- a/ios/RNPhotoManipulatorImpl.m
+++ b/ios/RNPhotoManipulatorImpl.m
@@ -174,7 +174,7 @@ static UIImage* printLine(UIImage *image, id options) {
     CGPoint position = [ParamUtils cgPoint:options[@"position"]];
 
     BOOL isRTL = isTextRTL([ParamUtils string:options[@"direction"]]);
-    NSTextAlignment alignment = isRTL ? NSTextAlignmentRight : NSTextAlignmentLeft;
+    NSTextAlignment alignment = toTextAlign(isRTL, [ParamUtils string:options[@"align"]]);
     CGPoint adjustedPosition = position;
     if (isRTL) adjustedPosition = CGPointMake(image.size.width - position.x, position.y);
     TextStyle *style = toTextStyle(options, alignment);
@@ -184,6 +184,12 @@ static UIImage* printLine(UIImage *image, id options) {
 
 static BOOL isTextRTL(NSString* text) {
     return [text isEqualToString:@"rtl"];
+}
+
+static NSTextAlignment toTextAlign(BOOL isRTL, NSString* align) {
+    if ([align isEqualToString:@"center"]) return NSTextAlignmentCenter;
+    if ([align isEqualToString:@"end"]) return isRTL ? NSTextAlignmentLeft : NSTextAlignmentRight;
+    return isRTL ? NSTextAlignmentRight : NSTextAlignmentLeft;
 }
 
 + (void)printText:(NSString *)uri

--- a/react-native-photo-manipulator.podspec
+++ b/react-native-photo-manipulator.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/guhungry/react-native-photo-manipulator.git", :tag => "#{s.version}" }
   s.source_files = "ios/**/*.{h,m,mm,cpp}"
 
-  s.dependency 'WCPhotoManipulator', '~> 2.5.0'
+  s.dependency 'WCPhotoManipulator', '~> 2.6.0'
 
   if respond_to?(:install_modules_dependencies, true)
     # React Native Core dependency

--- a/src/PhotoManipulatorTypes.ts
+++ b/src/PhotoManipulatorTypes.ts
@@ -10,6 +10,23 @@ export enum TextDirection {
   RTL = 'rtl',
 }
 
+export enum TextAlign {
+  /**
+   * Align text to the start of the line (e.g., left-aligned text in LTR scripts, right-aligned text in RTL scripts)
+   */
+  START = 'start',
+
+  /**
+   * Align text to the end of the line (e.g., right-aligned text in LTR scripts, left-aligned text in RTL scripts)
+   */
+  END = 'end',
+
+  /**
+   * Align text to the center of the line
+   */
+  CENTER = 'center',
+}
+
 export interface Point {
   x: number;
   y: number;
@@ -33,6 +50,7 @@ export interface TextOptions {
   shadowOffset?: Point;
   shadowColor?: string | Color;
   direction?: TextDirection;
+  align?: TextAlign;
 }
 
 export interface Color {


### PR DESCRIPTION
Add text alignment (START, CENTER, END), should address https://github.com/JimmyDaddy/react-native-image-marker/issues/83

Android:
<img width="221" alt="Screenshot 2567-10-26 at 10 51 36" src="https://github.com/user-attachments/assets/65435e28-12b4-435f-8808-bfda3a88cff8">

iOs:
<img width="187" alt="Screenshot 2567-10-26 at 11 39 55" src="https://github.com/user-attachments/assets/6a89ca47-047f-4fc9-8bc9-b6685b4a7ee2">
