### PR TITLE
Fix: Can't compile android in React Native 0.77

### DIFF
--- a/android/src/main/java/com/guhungry/rnphotomanipulator/RNPhotoManipulatorModule.kt
+++ b/android/src/main/java/com/guhungry/rnphotomanipulator/RNPhotoManipulatorModule.kt
@@ -163,7 +163,7 @@ class RNPhotoManipulatorModule(private val context: ReactApplicationContext) : R
             val output = bitmapFromUri(context, uri, mutableOptions())
 
             for (i in 0 until list.size()) {
-                val text = list.getMap(i)
+                val text = list.getMap(i) ?: continue
                 printLine(output, text.getString("text")!!, toPointF(text.getMap("position"))!!, text)
             }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-photo-manipulator",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "React Native Image Processing API to edit photo programmatically for Android and iOS.",
   "source": "./src/index.ts",
   "main": "./lib/commonjs/index.js",


### PR DESCRIPTION
React Native 0.77 has a breaking changes in interface for ReadableArray. Function getMap() returns ReadableMap? instead of ReadableMap in previous version.
<img width="807" alt="image" src="https://github.com/user-attachments/assets/7b035347-a9c9-4c49-b47a-80c6d5fae9b6" />
https://github.com/facebook/react-native/commit/145c72f8163048f0eee30d5ce850911f5dad865c#diff-07048d8ce95d0c2c1beea597aeb6912512b3e4608dafdccac7f93f67b4711bfaL82-R82

Should fix #1013